### PR TITLE
Generate and upload AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+sudo: required
+language: cpp
+dist: xenial
+compiler:
+- gcc
+os:
+- linux
+install:
+- echo $HOME
+- echo $PWD
+- sudo apt-get install libjpeg-dev libsndfile1-dev libsigc++-2.0-dev libfontconfig1-dev libxft-dev libcairo-dev python3-pip python3-setuptools python3-wheel liblo-dev libjack-dev libsamplerate0-dev ninja-build
+- if cd ntk; then git pull; else git clone git://git.tuxfamily.org/gitroot/non/fltk.git ntk && cd ntk; fi
+- sudo ./waf configure build install && cd ..
+- pip3 install meson
+script:
+- meson --prefix /usr build
+- ninja -C build
+- ninja -C build test
+- DESTDIR=./appdir ninja -C build install ; find ./build/appdir
+- wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+- chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+- unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+- ./linuxdeployqt-continuous-x86_64.AppImage build/appdir/usr/share/applications/*.desktop -appimage
+after_success:
+- wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+- bash upload.sh Luppp*.AppImage*  
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/
+cache: 
+  directories:
+    - $HOME/.cache/pip

--- a/meson.build
+++ b/meson.build
@@ -41,3 +41,7 @@ endforeach
 executable('luppp', luppp_src + [version_hxx],
     install: true,
     dependencies: deps)
+
+install_data('resources/metadata/luppp.desktop', install_dir: 'share/applications')
+install_data('resources/metadata/luppp.appdata.xml', install_dir: 'share/appdata')
+install_data('resources/icons/luppp.png', install_dir: 'share/pixmaps')


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter
- No repositories needed. Suitable/optimized for air-gapped (offline) machines

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE:__ For this to work, you need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.